### PR TITLE
libdrgn: dwarf_info: Support DW_TAG_GNU_template_parameter_pack

### DIFF
--- a/libdrgn/dwarf_info.c
+++ b/libdrgn/dwarf_info.c
@@ -6864,7 +6864,7 @@ drgn_compound_type_from_dwarf(struct drgn_debug_info *dbinfo,
 		dwarf_die_is_little_endian(die, false, &little_endian);
 	}
 
-	Dwarf_Die member = {}, child;
+	Dwarf_Die member = {}, child, child_param;
 	int r = dwarf_child(die, &child);
 	while (r == 0) {
 		switch (dwarf_tag(&child)) {
@@ -6900,6 +6900,17 @@ drgn_compound_type_from_dwarf(struct drgn_debug_info *dbinfo,
 						       &builder.template_builder);
 			if (err)
 				goto err;
+			break;
+		case DW_TAG_GNU_template_parameter_pack:
+			r = dwarf_child(&child, &child_param);
+			while (r == 0) {
+				err = parse_template_parameter(dbinfo, module, &child_param,
+							       drgn_dwarf_template_type_parameter_thunk_fn,
+							       &builder.template_builder);
+				if (err)
+					goto err;
+				r = dwarf_siblingof(&child_param, &child_param);
+			}
 			break;
 		case DW_TAG_inheritance:
 			err = parse_template_parameter(dbinfo, module, &child,

--- a/tests/test_dwarf.py
+++ b/tests/test_dwarf.py
@@ -1680,6 +1680,55 @@ class TestTypes(TestCase):
                 )
             ).type("TEST").type.template_parameters[0].argument
 
+    def test_class_template_parameter_pack(self):
+        prog = dwarf_program(
+            wrap_test_type_dies(
+                DwarfDie(
+                    DW_TAG.class_type,
+                    (
+                        DwarfAttrib(DW_AT.name, DW_FORM.string, "variant<int, char>"),
+                        DwarfAttrib(DW_AT.declaration, DW_FORM.flag_present, True),
+                    ),
+                    (
+                        DwarfDie(
+                            DW_TAG.GNU_template_parameter_pack,
+                            (
+                                DwarfAttrib(DW_AT.name, DW_FORM.string, "_Types"),
+                            ),
+                            (
+                                DwarfDie(
+                                    DW_TAG.template_type_parameter,
+                                    (
+                                        DwarfAttrib(DW_AT.type, DW_FORM.ref4, "int_die"),
+                                        DwarfAttrib(DW_AT.name, DW_FORM.string, "T"),
+                                    ),
+                                ),
+                                DwarfDie(
+                                    DW_TAG.template_type_parameter,
+                                    (
+                                        DwarfAttrib(DW_AT.type, DW_FORM.ref4, "char_die"),
+                                        DwarfAttrib(DW_AT.name, DW_FORM.string, "C"),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                *labeled_int_die,
+                *labeled_char_die,
+            )
+        )
+        self.assertIdentical(
+            prog.type("TEST").type,
+            prog.class_type(
+                "variant<int, char>",
+                template_parameters=(
+                    TypeTemplateParameter(prog.int_type("int", 4, True), "T"),
+                    TypeTemplateParameter(prog.int_type("char", 1, True), "C"),
+                ),
+            ),
+        )
+
     def test_lazy_cycle(self):
         prog = dwarf_program(
             wrap_test_type_dies(


### PR DESCRIPTION
This DWARF tag is used by C++ classes which take a variable number of template parameters, such as std::variant and std::tuple.

This commit is also in an upstream PR at https://github.com/osandov/drgn/pull/222
I'm also putting it here to get it into OI faster.